### PR TITLE
データベース設計の記述の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,47 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :groups,  through:  :groups_users
+- has_many :messages
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :users,  through:  :groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messageasテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
@@ -40,7 +40,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
@@ -63,6 +63,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
+|image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Things you may want to cover:
 ### Association
 - has_many :groups_users
 - has_many :users,  through:  :groups_users
+- has_many :messages
 
 ## groups_usersテーブル
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|


### PR DESCRIPTION
 # What
ChatSpaceの機能実現のため、ユーザー、グループ、ユーザーグループ（中間テーブル）、メッセージの4つのテーブルを作成する。
ユーザーテーブルとグループテーブルを多対多の関係に定義される。
メッセージテーブルは各グループチャットに表示されるため、ユーザIDとグループIDを外部キーとして持つ。

# Why
データベースの制作にあたって必要なテーブル及びリレーションの設定を確認してもらうため、READMEに想定する内容を記述する。
